### PR TITLE
feat: Add section with markdown rendering in contact page view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "friend-tracker",
-	"version": "1.1.0",
+	"version": "1.2.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "friend-tracker",
-			"version": "1.1.0",
+			"version": "1.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const STANDARD_FIELDS = {
 	CREATED: "created",
 	UPDATED: "updated",
 	NOTES: "notes",
+	EXTRAS: "extras",
 } as const;
 
 // System fields that shouldn't be shown as custom fields
@@ -21,6 +22,7 @@ export const SYSTEM_FIELDS: StandardFieldValue[] = [
 	STANDARD_FIELDS.CREATED,
 	STANDARD_FIELDS.UPDATED,
 	STANDARD_FIELDS.NOTES,
+	STANDARD_FIELDS.EXTRAS,
 ];
 
 // Fields that have special input handling

--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,8 @@ If your plugin does not need CSS, delete this file.
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	gap: 1rem;
+	margin-bottom: 32px;
 	padding: 12px 16px;
 	border-bottom: 2px solid var(--background-modifier-border);
 	position: sticky;
@@ -29,6 +31,21 @@ If your plugin does not need CSS, delete this file.
 	letter-spacing: 0.08em;
 	color: var(--text-muted);
 	margin: 0;
+}
+
+.friend-tracker-header select {
+	padding: var(--size-4-1) var(--size-4-2);
+	box-shadow: none !important;
+	border: 1px solid var(--background-modifier-border);
+	background-color: var(--background-modifier-form-field);
+}
+
+.friend-tracker-header select:hover {
+	border-color: var(--background-modifier-border-hover);
+}
+
+.friend-tracker-header select:focus {
+	outline: none;
 }
 
 .friend-tracker-add-button {
@@ -256,6 +273,48 @@ If your plugin does not need CSS, delete this file.
 .contact-interaction-item:hover .contact-interaction-actions {
 	opacity: 1;
 }
+
+/* Extras Section */
+.contact-extras-section {
+	padding: 20px;
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.contact-extras-section-list {
+	margin-top: 16px;
+}
+
+.contact-extras-section-item {
+	display: flex;
+	align-items: flex-start;
+	padding: 12px;
+	border-bottom: 1px solid var(--background-modifier-border);
+	gap: 12px;
+}
+
+.contact-extras-section-date {
+	color: var(--text-muted);
+	font-size: 0.9em;
+	width: 100px;
+	flex-shrink: 0;
+}
+
+.contact-extras-section-text {
+	flex: 1;
+	line-height: 1.4;
+}
+
+.contact-extras-section-actions {
+	display: flex;
+	gap: 8px;
+	opacity: 0;
+	transition: opacity 0.2s ease;
+}
+
+.contact-extras-section-item:hover .contact-extras-section-actions {
+	opacity: 1;
+}
+
 
 /* Buttons */
 .contact-add-field-button,


### PR DESCRIPTION
Thanks for a great plugin! 

Since I was using a similar structure, I often had extra content outside of the frontmatter (related links, relevant extra info, images, etc.). With a small update, those items get rendered now (only if they are there) as well . 